### PR TITLE
modify default FStype to xfs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -30,7 +30,9 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/connection"
-	"github.com/kubernetes-csi/external-provisioner/pkg/features"
+
+	// "github.com/kubernetes-csi/external-provisioner/pkg/features"
+	"github.com/kpaas-io/external-provisioner/pkg/features"
 	snapapi "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
 	snapclientset "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
@@ -105,7 +107,8 @@ const (
 	backoffFactor   = 1.2
 	backoffSteps    = 10
 
-	defaultFSType = "ext4"
+	// default fsType is ext4, we use xfs aviod jdb2 stuck problem
+	defaultFSType = "xfs"
 
 	snapshotKind     = "VolumeSnapshot"
 	snapshotAPIGroup = snapapi.GroupName       // "snapshot.storage.k8s.io"

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-csi/csi-lib-utils/connection"
 	"github.com/kubernetes-csi/csi-test/driver"
-	"github.com/kubernetes-csi/external-provisioner/pkg/features"
+
+	//"github.com/kubernetes-csi/external-provisioner/pkg/features"
+	"github.com/kpaas-io/external-provisioner/pkg/features"
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
 	"github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned/fake"
 	"google.golang.org/grpc"


### PR DESCRIPTION
kubernetes-csi 部分以及其他引用到该库的其他库中定义文件系统的部分在 pkg/controller/controller.go 内，defaultFSType 字段，默认不定义时为 ext4，这里我想改为 xfs，默认以后就不使用 ext4 了。

测试方面，有点想法：
1. 在虚拟机/物理机上都应该测试
2. 测试应该包含新建pv/pvc，绑定 pod，挂载点，lsblk 观察 fstype，删除pv/pvc，删除镜像等。
3. 在测试时观察之前已经存在的 ext4 的表现，尝试删除旧的 pvc/pv 看是否有影响
4. 待补充

@fatsheep9146 